### PR TITLE
Avoid download site broken JS: inbound download link to https site 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </a>
 
 ### Download
-[Download the TWS API here](http://interactivebrokers.github.io)
+[Download the TWS API here](https://interactivebrokers.github.io)
 
 ### Contribute
-[Learn how to contribute to the API here](http://interactivebrokers.github.io/api_software_contribute.html)
+[Learn how to contribute to the API here](https://interactivebrokers.github.io/api_software_contribute.html)

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 [Download the TWS API here](https://interactivebrokers.github.io)
 
 ### Contribute
-[Learn how to contribute to the API here](https://interactivebrokers.github.io/api_software_contribute.html)
+[Learn how to contribute to the API here](http://interactivebrokers.github.io/api_software_contribute.html)


### PR DESCRIPTION
Change Readme link to _https_ for github.io inbound download link, to fix agree button behavior.

Avoids JS errors resulting from missing jquery.min.js via http, which disengage the agree button.

